### PR TITLE
Simple fix for "require" test not to fail.

### DIFF
--- a/Autoastrom.pm
+++ b/Autoastrom.pm
@@ -37,6 +37,8 @@ use Astro::Coords;
 use Astro::Correlate;
 use Astro::Catalog;
 use Astro::Catalog::Query::SkyCat;
+use Astro::Flux;
+use Astro::Fluxes;
 use Astro::FITS::HdrTrans qw/ translate_from_FITS /;
 use Astro::FITS::Header;
 use Astro::FITS::Header::NDF;


### PR DESCRIPTION
I have added "use Astro::Flux*;" in the main module; otherwise "require" test was failing.
